### PR TITLE
changed the display of the tags

### DIFF
--- a/blog/natas1-5.html
+++ b/blog/natas1-5.html
@@ -40,7 +40,7 @@
                 <div class="content">
                     <h3>Natas levels 1-5</h3>
                     <time datetime="12-12-2020">DEC. 14, 2020</time>
-                    <a href="../tag/write-ups.html">#Write-ups</a><br> 
+                    <a href="tag/write-ups.html">#Write-ups</a><br> 
                     <p>
                         A write-up of the first couple levels of Natas, an Over the Wire Wargame. xD 
                     </p>

--- a/styles/main.css
+++ b/styles/main.css
@@ -36,15 +36,20 @@ a:visited {
     border: none; 
 }
 .tags {
-    display: inline-block;
+    display: flex; 
+    flex-wrap: wrap; 
     padding: 50px; 
     padding-left: 0; 
 }
+
 .tag-button, .tag-button:visited {
     color: var(--color-1);
     text-decoration: none;  
     background-color: rgb(114, 214, 68);
     padding: 10px 20px;
+    margin: 5px; 
+    margin-left: 0; 
+    margin-right: 10px;
 }
 
 .tag-button:hover {
@@ -134,10 +139,9 @@ body {
     background: var(--bg-color-1);
     font-family: 'Space Mono', monospace;
     margin: 0;
-    padding: 0;
-    width: 100%; 
-    overflow-x: hidden; 
-
+    padding: 0; 
+    width: auto; 
+    overflow-x: hidden;
 }
 
 main {
@@ -145,7 +149,7 @@ main {
     grid-template-columns: 2fr 1fr; 
     column-gap: 10px;
     padding: 10%; 
-    padding-top: 50px; 
+    padding-top: 50px;  
 }
 /*------------Background CSS--------------------------*/
 .background-one {


### PR DESCRIPTION
I changed the display of the tags in blog to use flexbox rather than inline-block. I noticed this small little issue on mobile that the tags would overlap once they wrapped and I couldn't figure out how to fix it other than to use flexbox and wrap. I also don't know what's causing that overflow issue but I guess I'll keep experimenting until I figure it out.